### PR TITLE
Benchmark + Performance Improvements

### DIFF
--- a/bench.rb
+++ b/bench.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+require "benchmark/ips"
+
+module ClassVariants
+end
+
+require_relative "lib/class_variants/instance"
+
+
+Benchmark.ips do |x|
+  button_classes = ClassVariants::Instance.new(
+    "rounded border-2 focus:ring-blue-500",
+    variants: {
+      size: {
+        sm: "text-xs px-1.5 py-1",
+        base: "text-sm px-2 py-1.5",
+        lg: "text-base px-3 py-2",
+      },
+      color: {
+        white: "text-white bg-transparent border-white",
+        blue: "text-white bg-blue-500 border-blue-700 hover:bg-blue-600",
+        red: "text-white bg-red-500 border-red-700 hover:bg-red-600",
+      },
+    },
+    defaults: {
+      size: :base,
+      color: :white,
+    }
+  )
+
+  x.report("rendering only defaults") do
+    button_classes.render
+  end
+
+  x.report("rendering with overrides") do
+    button_classes.render(size: :sm, color: :red)
+  end
+end

--- a/class_variants.gemspec
+++ b/class_variants.gemspec
@@ -21,5 +21,7 @@ Gem::Specification.new do |s|
     raise "RubyGems 2.0 or newer is required to protect against " \
       "public gem pushes."
   end
+
+  s.add_development_dependency "benchmark-ips"
 end
 

--- a/lib/class_variants/instance.rb
+++ b/lib/class_variants/instance.rb
@@ -26,10 +26,10 @@ class ClassVariants::Instance
       end
     end
 
-    if defaults.present?
+    if defaults && !defaults.empty?
       defaults.each do |key, key_to_use|
         unless applied_options.include? key
-          result << @variants[key][key_to_use] if @variants[key].present?
+          result << @variants[key][key_to_use] if @variants[key] && !@variants[key].empty?
         end
       end
     end

--- a/lib/class_variants/instance.rb
+++ b/lib/class_variants/instance.rb
@@ -9,31 +9,21 @@ class ClassVariants::Instance
     @defaults = defaults
   end
 
-  def render(**settings)
-    result = []
+  def render(**overrides)
+    # Start with our default classes
+    result = [@classes]
 
-    # Add the default classes if any provided
-    result << classes if classes
-
-    # Keep the applied variants so we can later apply the defaults
-    applied_options = []
-
-    # Go through each keys provided
-    settings.each do |key, value|
-      if variants.keys.include? key
-        applied_options << key
-        result << variants[key][value]
+    # Then merge the passed in overrides on top of the defaults
+    @defaults.merge(overrides)
+      .each do |variant_type, variant|
+        # dig the classes out and add them to the result
+        result << @variants.dig(variant_type, variant)
       end
-    end
 
-    if defaults && !defaults.empty?
-      defaults.each do |key, key_to_use|
-        unless applied_options.include? key
-          result << @variants[key][key_to_use] if @variants[key] && !@variants[key].empty?
-        end
-      end
-    end
+    # Compact out any nil values we may have dug up
+    result.compact!
 
+    # Return the final token list
     result.join " "
   end
 end


### PR DESCRIPTION
Hi 👋 

First off, thanks for making this gem! I love it ❤️ 

When I was looking at the render implementation I had a few ideas for things that might make it a little faster. I knew I would need to add a benchmark to measure any results though so I added that first. While I was setting that up I discovered that there was an implicit dependency on active_support with the use of `present?`, which is not a Ruby core method. I removed that by expanding those uses out into what `present?` would have done, which is a falsey check, and then an empty check.


<details>
<summary>Then I added the benchmark and took initial measurements</summary>

```
Warming up --------------------------------------
rendering only defaults
                       129.242k i/100ms
rendering with overrides
                       107.147k i/100ms
Calculating -------------------------------------
rendering only defaults
                          1.278M (± 2.4%) i/s -      6.462M in   5.060689s
rendering with overrides
                          1.051M (± 2.6%) i/s -      5.250M in   5.000286s
```

</details>

The main performance gains came from 3 changes as far as I could tell:
* Merging `overrides` (née `settings`) onto defaults, and iterating that result once. Instead of iterating both of them individually and keeping track of which settings were set
* Using the instance variables directly instead of accessing them through the `attr_reader`s
* Removing the conditional checks before appending to `result` and instead using a single `compact!` at the end

I tried out a few other things I could think of, but they only made the performance worse.

<details>
<summary>This was my final benchmark after these performance improvements were made</summary>

```
Perf
Warming up --------------------------------------
rendering only defaults
                       186.738k i/100ms
rendering with overrides
                       162.322k i/100ms
Calculating -------------------------------------
rendering only defaults
                          1.851M (± 2.3%) i/s -      9.337M in   5.045712s
rendering with overrides
                          1.610M (± 2.5%) i/s -      8.116M in   5.045476s
```

</details>

According to my napkin math that's about a 55% improvement on the "rendering with overrides" case, and a 44% improvement on the "rendering only defaults" case.