### PR TITLE
Boolean Variants proposal

### DIFF
--- a/bench.rb
+++ b/bench.rb
@@ -21,10 +21,13 @@ Benchmark.ips do |x|
         blue: "text-white bg-blue-500 border-blue-700 hover:bg-blue-600",
         red: "text-white bg-red-500 border-red-700 hover:bg-red-600",
       },
+      block: "justify-center w-full",
+      "!block": "justify-between",
     },
     defaults: {
       size: :base,
       color: :white,
+      block: false,
     }
   )
 
@@ -33,6 +36,6 @@ Benchmark.ips do |x|
   end
 
   x.report("rendering with overrides") do
-    button_classes.render(size: :sm, color: :red)
+    button_classes.render(size: :sm, color: :red, block: true)
   end
 end

--- a/lib/class_variants/instance.rb
+++ b/lib/class_variants/instance.rb
@@ -5,7 +5,7 @@ class ClassVariants::Instance
 
   def initialize(classes = "", variants: {}, defaults: {})
     @classes = classes
-    @variants = variants
+    @variants = expand_boolean_variants(variants)
     @defaults = defaults
   end
 
@@ -25,5 +25,21 @@ class ClassVariants::Instance
 
     # Return the final token list
     result.join " "
+  end
+
+  private
+
+  def expand_boolean_variants(variants)
+    variants.each.map { |key, value|
+      case value
+      when String
+        s_key = key.to_s
+        { s_key.delete_prefix("!").to_sym => { !s_key.start_with?("!") => value } }
+      else
+        { key => value }
+      end
+    }.reduce do |variants, more_variants|
+      variants.merge!(more_variants) { |_key, v1, v2| v1.merge!(v2) }
+    end
   end
 end

--- a/readme.md
+++ b/readme.md
@@ -52,17 +52,24 @@ button_classes = ClassVariants.build(
       red: "bg-red-600 hover:bg-red-700 focus:ring-red-500",
       blue: "bg-blue-600 hover:bg-blue-700 focus:ring-blue-500",
     },
+    # A variant whose value is a string will be expanded into a hash that looks
+    # like  { true => "classes" }
+    block: "w-full justify-center",
+    # Unless the key starts with !, in which case it will expand into
+    # { false => "classes" }
+    "!block": "w-auto",
   },
   defaults: {
     size: :md,
     color: :indigo,
+    icon: false
   }
 )
 
 # Call it with our desired variants
 button_classes.render(color: :blue, size: :sm)
 button_classes.render
-button_classes.render(color: :red, size: :xl)
+button_classes.render(color: :red, size: :xl, icon: true)
 ```
 
 ## Use with Rails


### PR DESCRIPTION
This is an API I've been playing around with in my own projects for defining boolean variants. This is just a proposal, and I'm definitely open to API suggestions, or just scrapping it altogether if it's not beneficial.

Boolean variants work by defining a variant and setting it's value to a String.

```ruby
classes = ClassVariants.build(
  variants: {
    block: "w-full justify-center"
  },
  defaults: {
    block: false
  }
)
classes.render # => ""
classes.render(block: true) # => "w-full justify-center"
```

A part of the API that I'm less sure is a good idea is the ability to define the inverse by prefixing the key with a `!`.

```ruby
classes = ClassVariants.build(
  variants: {
    block: "w-full justify-center",
    "!block": "w-auto"
  },
  defaults: {
    block: false
  }
)

classes.render # => "w-auto"
classes.render(block: true) # => "w-full justify-center"
```

I'm less confident because I don't love that you have to quote the key to make it a valid symbol, and it's also maybe just easier/clearer at that point to define the variant like so:

```ruby
classes = ClassVariants.build(
  variants: {
    block: {
      true => "w-full justify-center",
      false => "w-auto",
    },
  },
  defaults: {
    block: false
  }
)
```

The implementation I currently have has no effect on render speed, because it expands the boolean variants into normal hash/enum variants at initialization time. However it could negatively impact performance if the users application is creating lots of `ClassVariants` objects. In my use case, I'm using this inside a Phlex view, and it's stored in a constant, so these objects are getting built at start up and then left in memory for the life span of the application. In that use case, this would be a zero cost abstraction during view rendering.

I considered using a `!` suffix instead of a prefix, because that is a valid symbol without the need for quoting, which looks nicer in my opinion. But that pattern is being used in Phlex to define overrides, and this is not the same as that. I'd hate to overload patterns like that with different meanings. And `!` at the end is not connotative of `not` in ruby, so it doesn't work as well for expressing the meaning.