### PR TITLE
Deprecate usage of positional arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Deprecate usage of positional arguments ([#12](https://github.com/avo-hq/class_variants/pull/12))
 
 ## 0.0.7 (2023-12-07)
 - Add support for compound variants ([#8](https://github.com/avo-hq/class_variants/pull/8))

--- a/lib/class_variants.rb
+++ b/lib/class_variants.rb
@@ -5,8 +5,8 @@ require "class_variants/railtie" if defined?(Rails)
 
 module ClassVariants
   class << self
-    def build(classes, **args)
-      Instance.new classes, **args
+    def build(...)
+      Instance.new(...)
     end
   end
 end

--- a/lib/class_variants/instance.rb
+++ b/lib/class_variants/instance.rb
@@ -1,10 +1,15 @@
 module ClassVariants
   class Instance
-    attr_reader :classes, :variants, :compoundVariants, :defaults
+    attr_reader :base, :variants, :compoundVariants, :defaults
 
     # rubocop:disable Naming/VariableName
-    def initialize(classes = "", variants: {}, compoundVariants: [], defaults: {})
-      @classes = classes
+    def initialize(classes = nil, base: nil, variants: {}, compoundVariants: [], defaults: {})
+      warn <<~MSG if classes
+        (ClassVariants) DEPRECATION WARNING: Use of positional argument for default classes is deprecated
+        and will be removed in the next version. Use the `base` keyword argument instead.
+      MSG
+
+      @base = base || classes
       @variants = expand_boolean_variants(variants)
       @compoundVariants = compoundVariants
       @defaults = defaults
@@ -13,7 +18,7 @@ module ClassVariants
 
     def render(**overrides)
       # Start with our default classes
-      result = [@classes]
+      result = [@base]
 
       # Then merge the passed in overrides on top of the defaults
       selected = @defaults.merge(overrides)

--- a/readme.md
+++ b/readme.md
@@ -33,9 +33,9 @@ $ gem install class_variants
 
 We create an object from the class or helper where we define the configuration using four arguments:
 
-1. The default classes that should be applied to each variant
-1. The `variants` keyword argument where we declare the variants with their option and classes
-1. The `compoundVariants` keyword argument where we declare the compound variants with their conditions and classes
+1. The `base` keyword argument with default classes that should be applied to each variant.
+1. The `variants` keyword argument where we declare the variants with their option and classes.
+1. The `compoundVariants` keyword argument where we declare the compound variants with their conditions and classes.
 1. The `defaults` keyword argument (optional) where we declare the default value for each variant.
 
 ## Example
@@ -45,7 +45,7 @@ Below we implement the [button component](https://tailwindui.com/components/appl
 ```ruby
 # Define the variants and defaults
 button_classes = ClassVariants.build(
-  "inline-flex items-center rounded border border-transparent font-medium text-white hover:text-white shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2",
+  base: "inline-flex items-center rounded border border-transparent font-medium text-white hover:text-white shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2",
   variants: {
     size: {
       sm: "px-2.5 py-1.5 text-xs",
@@ -82,7 +82,7 @@ button_classes.render(color: :red, size: :xl, icon: true)
 
 ```ruby
 button_classes = ClassVariants.build(
-  "inline-flex items-center rounded",
+  base: "inline-flex items-center rounded",
   variants: {
     color: {
       red:  "bg-red-600",
@@ -105,7 +105,8 @@ button_classes.render(color: :red, border: true) # => "inline-flex items-center 
 ```ruby
 # Somewhere in your helpers
 def button_classes(classes, **args)
-  class_variants("inline-flex items-center rounded border border-transparent font-medium text-white hover:text-white shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2",
+  class_variants(
+    base: "inline-flex items-center rounded border border-transparent font-medium text-white hover:text-white shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2",
     variants: {
       size: {
         sm: "px-2.5 py-1.5 text-xs",

--- a/test/class_variants_test.rb
+++ b/test/class_variants_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class ClassVariantsTest < Minitest::Test
   def setup
     @cv = ClassVariants.build(
-      "rounded border",
+      base: "rounded border",
       variants: {
         size: {
           sm: "text-sm",


### PR DESCRIPTION
This PR adds a deprecation warning when a positional argument is used. In draft until #11 is merged. After this, a new version of the gem should be released so that developers can prepare for the new changes.