### PR TITLE
Add support for post process classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Add support for slots ([#15](https://github.com/avo-hq/class_variants/pull/15))
 - Allow passing additional classes when render ([#17](https://github.com/avo-hq/class_variants/pull/17))
 - Add helper module for defining variants ([#18](https://github.com/avo-hq/class_variants/pull/18))
+- Add support for post process classes ([#16](https://github.com/avo-hq/class_variants/pull/16))
 
 ## 0.0.8 (2024-10-24)
 - Deprecate usage of positional arguments ([#12](https://github.com/avo-hq/class_variants/pull/12))

--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,7 @@ gem "rubocop-minitest", require: false
 gem "rubocop-rake", require: false
 gem "standard", ">= 1.35.1", require: false
 gem "standard-performance", require: false
+
+install_if -> { !RUBY_VERSION.start_with?("3.0") } do
+  gem "tailwind_merge"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,7 @@ GEM
     json (2.7.2)
     language_server-protocol (3.17.0.3)
     lint_roller (1.1.0)
+    lru_redux (1.1.0)
     minitest (5.25.1)
     parallel (1.26.3)
     parser (3.3.5.0)
@@ -64,6 +65,8 @@ GEM
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.22.0)
     stringio (3.1.1)
+    tailwind_merge (0.13.1)
+      lru_redux (~> 1.1)
     unicode-display_width (2.6.0)
 
 PLATFORMS
@@ -81,6 +84,7 @@ DEPENDENCIES
   rubocop-rake
   standard (>= 1.35.1)
   standard-performance
+  tailwind_merge
 
 BUNDLED WITH
    2.5.20

--- a/lib/class_variants.rb
+++ b/lib/class_variants.rb
@@ -1,11 +1,20 @@
 require "class_variants/version"
 require "class_variants/action_view/helpers"
+require "class_variants/configuration"
 require "class_variants/instance"
 require "class_variants/helper"
 require "class_variants/railtie" if defined?(Rails)
 
 module ClassVariants
   class << self
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
+    def configure(&block)
+      yield(configuration)
+    end
+
     def build(...)
       Instance.new(...)
     end

--- a/lib/class_variants/configuration.rb
+++ b/lib/class_variants/configuration.rb
@@ -1,0 +1,11 @@
+module ClassVariants
+  class Configuration
+    def process_classes_with(&block)
+      if block_given?
+        @process_classes_with = block
+      else
+        @process_classes_with
+      end
+    end
+  end
+end

--- a/lib/class_variants/instance.rb
+++ b/lib/class_variants/instance.rb
@@ -34,7 +34,7 @@ module ClassVariants
       result.compact!
 
       # Return the final token list
-      result.join " "
+      with_classess_processor(result.join(" "))
     end
 
     private
@@ -95,6 +95,14 @@ module ClassVariants
     def expand_compound_variants(compound_variants)
       compound_variants.map do |compound_variant|
         compound_variant.merge(slot: :default)
+      end
+    end
+
+    def with_classess_processor(classes)
+      if ClassVariants.configuration.process_classes_with.respond_to?(:call)
+        ClassVariants.configuration.process_classes_with.call(classes)
+      else
+        classes
       end
     end
   end

--- a/lib/generators/class_variants/install/USAGE
+++ b/lib/generators/class_variants/install/USAGE
@@ -1,0 +1,2 @@
+Description:
+    Generates initializer file for configure ClassVariants in your application.

--- a/lib/generators/class_variants/install/install_generator.rb
+++ b/lib/generators/class_variants/install/install_generator.rb
@@ -1,0 +1,11 @@
+module ClassVariants
+  module Generators
+    class InstallGenerator < Rails::Generators::Base
+      source_root File.expand_path("templates", __dir__)
+
+      def copy_initializer
+        template "class_variants.rb", "config/initializers/class_variants.rb"
+      end
+    end
+  end
+end

--- a/lib/generators/class_variants/install/templates/class_variants.rb.tt
+++ b/lib/generators/class_variants/install/templates/class_variants.rb.tt
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# ClassVariants.configure do |config|
+#   # allow to post process classes with an external utility like TailwindMerger
+#   config.process_classes_with do |classes|
+#     TailwindMerge::Merger.new.merge(classes)
+#   end
+# end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class ConfigurationTest < Minitest::Test
+  def teardown
+    ClassVariants.configuration.instance_variable_set(:@process_classes_with, nil)
+  end
+
+  def test_configuration_process_classes_with_default
+    refute ClassVariants.configuration.process_classes_with
+  end
+
+  def test_configure
+    ClassVariants.configure do |config|
+      config.process_classes_with { |classes| classes }
+    end
+
+    assert_respond_to ClassVariants.configuration.process_classes_with, :call
+  end
+end

--- a/test/process_classes_with_test.rb
+++ b/test/process_classes_with_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class ProcessClassesWithTest < Minitest::Test
+  def teardown
+    ClassVariants.configuration.instance_variable_set(:@process_classes_with, nil)
+  end
+
+  def test_without_classes_processor
+    assert_equal "border rounded px-2 py-1 p-5", ClassVariants.build(base: "border rounded px-2 py-1 p-5").render
+  end
+
+  def test_with_classes_processor
+    ClassVariants.configure do |config|
+      config.process_classes_with do |classes|
+        merger.merge(classes)
+      end
+    end
+
+    assert_equal "border rounded p-5", ClassVariants.build(base: "border rounded px-2 py-1 p-5").render
+  end
+
+  private
+
+  def merger
+    require "tailwind_merge"
+    TailwindMerge::Merger.new
+  rescue LoadError
+    Class.new do
+      def merge(classes)
+        classes.gsub("px-2 py-1 ", "")
+      end
+    end.new
+  end
+end


### PR DESCRIPTION
This PR implements TailwindMerge and its configuration. It has been implemented globally so that the cache it incorporates is shared and used by all ClassVariants instances.