### PR TITLE
Add support for merging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- Add support for merging ([#23](https://github.com/avo-hq/class_variants/pull/23))
+
 ## 1.0.0 (2024-11-13)
 - Add support for slots ([#15](https://github.com/avo-hq/class_variants/pull/15))
 - Allow passing additional classes when render ([#17](https://github.com/avo-hq/class_variants/pull/17))

--- a/test/merge_test.rb
+++ b/test/merge_test.rb
@@ -1,0 +1,71 @@
+require "test_helper"
+
+class MergeTest < Minitest::Test
+  def test_hash_merge
+    cv = ClassVariants.build(
+      base: "rounded",
+      variants: {
+        color: {
+          primary: "bg-blue-500",
+          secondary: "bg-purple-500",
+          success: "bg-green-500"
+        }
+      },
+      default: {
+        color: :primary
+      }
+    )
+    cv.merge(
+      base: "border",
+      variants: {
+        color: {
+          primary: "bg-blue-700",
+          secondary: "bg-purple-700"
+        }
+      },
+      defaults: {
+        color: :secondary
+      }
+    )
+
+    assert_equal "rounded border bg-purple-500 bg-purple-700", cv.render
+  end
+
+  def test_block_merge
+    cv = ClassVariants.build do
+      base do
+        slot :root, class: "rounded"
+        slot :title, class: "font-bold"
+      end
+
+      variant variant: :outlined do
+        slot :root, class: "border-red-700"
+        slot :title, class: "text-red-700"
+      end
+
+      variant variant: :filled do
+        slot :root, class: "bg-red-100"
+        slot :title, class: "text-red-900"
+      end
+
+      defaults variant: :outlined
+    end
+
+    cv.merge do
+      base do
+        slot :root, class: "mb-4"
+        slot :title, class: "mb-1"
+      end
+
+      variant variant: :filled do
+        slot :root, class: "dark:bg-red-800"
+        slot :title, class: "dark:text-red-50"
+      end
+
+      defaults variant: :filled
+    end
+
+    assert_equal "rounded mb-4 bg-red-100 dark:bg-red-800", cv.render(:root)
+    assert_equal "font-bold mb-1 text-red-900 dark:text-red-50", cv.render(:title)
+  end
+end


### PR DESCRIPTION
@adrianthedev  This PR adds support for calling the function that sets up variants multiple times. The ultimate goal is to allow a subclass of a class that uses class_variants to add its own logic to the original, though that part will go into another PR dedicated exclusively to modifying the helper to allow inheritance.