### PR TITLE
Micro performance optimisations

### DIFF
--- a/bench.rb
+++ b/bench.rb
@@ -1,35 +1,37 @@
+#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 require "benchmark/ips"
+require "class_variants"
 
-module ClassVariants
-end
+RubyVM::YJIT.enable
 
-require_relative "lib/class_variants/instance"
+button_classes = ClassVariants.build(
+  base: "rounded border-2 focus:ring-blue-500",
+  variants: {
+    size: {
+      sm: "text-xs px-1.5 py-1",
+      base: "text-sm px-2 py-1.5",
+      lg: "text-base px-3 py-2"
+    },
+    color: {
+      white: "text-white bg-transparent border-white",
+      blue: "text-white bg-blue-500 border-blue-700 hover:bg-blue-600",
+      red: "text-white bg-red-500 border-red-700 hover:bg-red-600"
+    },
+    block: "justify-center w-full",
+    "!block": "justify-between"
+  },
+  defaults: {
+    size: :base,
+    color: :white,
+    block: false
+  }
+)
 
 Benchmark.ips do |x|
-  button_classes = ClassVariants::Instance.new(
-    "rounded border-2 focus:ring-blue-500",
-    variants: {
-      size: {
-        sm: "text-xs px-1.5 py-1",
-        base: "text-sm px-2 py-1.5",
-        lg: "text-base px-3 py-2"
-      },
-      color: {
-        white: "text-white bg-transparent border-white",
-        blue: "text-white bg-blue-500 border-blue-700 hover:bg-blue-600",
-        red: "text-white bg-red-500 border-red-700 hover:bg-red-600"
-      },
-      block: "justify-center w-full",
-      "!block": "justify-between"
-    },
-    defaults: {
-      size: :base,
-      color: :white,
-      block: false
-    }
-  )
+  x.warmup = 5
+  x.time = 20
 
   x.report("rendering only defaults") do
     button_classes.render

--- a/lib/class_variants.rb
+++ b/lib/class_variants.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "class_variants/version"
 require "class_variants/action_view/helpers"
 require "class_variants/configuration"

--- a/lib/class_variants/action_view/helpers.rb
+++ b/lib/class_variants/action_view/helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ClassVariants
   module ActionView
     module Helpers

--- a/lib/class_variants/configuration.rb
+++ b/lib/class_variants/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ClassVariants
   class Configuration
     def process_classes_with(&block)

--- a/lib/class_variants/helper.rb
+++ b/lib/class_variants/helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ClassVariants
   module Helper
     module ClassMethods

--- a/lib/class_variants/instance.rb
+++ b/lib/class_variants/instance.rb
@@ -107,9 +107,10 @@ module ClassVariants
     end
 
     def with_slots
-      @slots = []
+      new_slots = []
+      @slots = new_slots
       yield
-      @slots
+      new_slots
     end
 
     def expand_variants(variants)

--- a/lib/class_variants/instance.rb
+++ b/lib/class_variants/instance.rb
@@ -48,9 +48,15 @@ module ClassVariants
       @variants.each do |candidate|
         next unless candidate[:slot] == slot
 
-        if (candidate.keys - [:class, :slot]).all? { |key| criteria[key] == candidate[key] }
-          result << candidate[:class]
+        match = false
+
+        candidate.each_key do |key|
+          next if key == :class || key == :slot
+          match = criteria[key] == candidate[key]
+          break unless match
         end
+
+        result << candidate[:class] if match
       end
 
       # add the passed in classes to the result

--- a/lib/class_variants/instance.rb
+++ b/lib/class_variants/instance.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ClassVariants
   class Instance
     def initialize(...)

--- a/lib/class_variants/instance.rb
+++ b/lib/class_variants/instance.rb
@@ -19,7 +19,7 @@ module ClassVariants
     end
 
     def merge(**options, &block)
-      raise ArgumentError, "Use of hash config and code block is not supported" if !options.empty? && block_given?
+      raise ArgumentError, "Use of hash config and code block is not supported" if !options.empty? && block
 
       (base = options.fetch(:base, nil)) && @bases << {class: base, slot: :default}
       @variants += [
@@ -28,7 +28,7 @@ module ClassVariants
       ].inject(:+)
       @defaults.merge!(options.fetch(:defaults, {}))
 
-      instance_eval(&block) if block_given?
+      instance_eval(&block) if block
 
       self
     end
@@ -66,9 +66,9 @@ module ClassVariants
     private
 
     def base(klass = nil, &block)
-      raise ArgumentError, "Use of positional argument and code block is not supported" if klass && block_given?
+      raise ArgumentError, "Use of positional argument and code block is not supported" if klass && block
 
-      if block_given?
+      if block
         with_slots(&block).each do |slot|
           @bases << slot
         end
@@ -78,9 +78,9 @@ module ClassVariants
     end
 
     def variant(**options, &block)
-      raise ArgumentError, "Use of class option and code block is not supported" if options.key?(:class) && block_given?
+      raise ArgumentError, "Use of class option and code block is not supported" if options.key?(:class) && block
 
-      if block_given?
+      if block
         with_slots(&block).each do |slot|
           @variants << options.merge(slot)
         end

--- a/lib/class_variants/instance.rb
+++ b/lib/class_variants/instance.rb
@@ -6,6 +6,7 @@ module ClassVariants
       @bases = []
       @variants = []
       @defaults = {}
+      @slots = nil
 
       merge(...)
     end

--- a/lib/class_variants/railtie.rb
+++ b/lib/class_variants/railtie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails/railtie"
 
 module ClassVariants

--- a/lib/class_variants/version.rb
+++ b/lib/class_variants/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ClassVariants
-  VERSION = "1.1.0".freeze
+  VERSION = "1.1.0"
 end

--- a/lib/generators/class_variants/install/install_generator.rb
+++ b/lib/generators/class_variants/install/install_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ClassVariants
   module Generators
     class InstallGenerator < Rails::Generators::Base


### PR DESCRIPTION
I was nerd-sniped when I spotted `bench.rb` in the repo and I made a few changes. I think the behaviour is the same as before. At least all the original tests still pass.

I had to fix the benchmark script, which I think was using an older API. I also made it executable so you can run it with `bundle exec ./bench.rb` and I made it enable YJIT.

Each optimisation is in its own commit. The overall improvement is about 13%.

- `rendering only defaults` was `683.473k` now `774.274k` IPS
- `rendering with overrides` was `628.236k` now `712.929k` IPS