### PR TITLE
Fix inherited hook in helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- Fix issue with inherited hook in helper ([#33](https://github.com/avo-hq/class_variants/pull/33))
+
 ## 1.1.0 (2025-01-20)
 - Add support for merging ([#23](https://github.com/avo-hq/class_variants/pull/23))
 - Add support for subclass inheritance in helper ([#24](https://github.com/avo-hq/class_variants/pull/24))

--- a/lib/class_variants/helper.rb
+++ b/lib/class_variants/helper.rb
@@ -11,9 +11,12 @@ module ClassVariants
     def self.included(base)
       base.extend(ClassMethods)
       base.singleton_class.instance_variable_set(:@_class_variants_instance, ClassVariants::Instance.new)
-      base.define_singleton_method(:inherited) do |subclass|
+
+      def base.inherited(subclass)
+        super if defined?(super)
+
         subclass.singleton_class.instance_variable_set(
-          :@_class_variants_instance, base.singleton_class.instance_variable_get(:@_class_variants_instance).dup
+          :@_class_variants_instance, singleton_class.instance_variable_get(:@_class_variants_instance).dup
         )
       end
     end

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -1,14 +1,28 @@
 require "test_helper"
 
 class HelperTest < Minitest::Test
-  class DemoClass
+  class BaseClass
+  end
+
+  class DemoClass < BaseClass
     include ClassVariants::Helper
 
     class_variants base: "rounded border"
   end
 
-  class Subclass < DemoClass
+  class SubClass < DemoClass
     class_variants base: "bg-black"
+  end
+
+  def test_inherited
+    mock = Minitest::Mock.new
+    mock.expect(:call, nil, [Class])
+
+    BaseClass.stub(:inherited, mock) do
+      Class.new(DemoClass)
+    end
+
+    mock.verify
   end
 
   def test_call_from_instance
@@ -16,6 +30,6 @@ class HelperTest < Minitest::Test
   end
 
   def test_call_from_subclass
-    assert_equal "rounded border bg-black", Subclass.new.class_variants
+    assert_equal "rounded border bg-black", SubClass.new.class_variants
   end
 end


### PR DESCRIPTION
This PR fixes a bug in the helper. As implemented, if the original class or any of its ancestors already had the self.inherited hook defined, it was never called because it was being overridden by the helper.

In my case, it was causing a conflict with the ViewComponent gem https://github.com/ViewComponent/view_component/blob/main/lib/view_component/base.rb#L516