### PR TITLE
Correctly list `compound_variants` output in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -98,7 +98,7 @@ button_classes = ClassVariants.build(
 )
 
 button_classes.render(color: :red) # => "inline-flex items-center rounded bg-red-600"
-button_classes.render(color: :red, border: true) # => "inline-flex items-center rounded bg-red-600 border border-red-600"
+button_classes.render(color: :red, border: true) # => "inline-flex items-center rounded bg-red-600 border border-red-800"
 ```
 
 ## Override classes with `render`


### PR DESCRIPTION
If I understand `compound_variants` correctly, then this should be `border-red-800` because of line 95:

```
{ color: :red,  border: true, class: "border-red-800"  },
```