### PR TITLE
Deprecate usage of positional argument for slot in render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 - Fix issue with inherited hook in helper ([#33](https://github.com/avo-hq/class_variants/pull/33))
+- Deprecate usage of positional argument for slot in render ([#40](https://github.com/avo-hq/class_variants/pull/40))
 
 ## 1.1.0 (2025-01-20)
 - Add support for merging ([#23](https://github.com/avo-hq/class_variants/pull/23))

--- a/lib/class_variants/instance.rb
+++ b/lib/class_variants/instance.rb
@@ -34,7 +34,13 @@ module ClassVariants
       self
     end
 
-    def render(slot = :default, **overrides)
+    def render(slot = nil, **overrides)
+      warn <<~MSG if slot
+        (ClassVariants) DEPRECATION WARNING: Use of positional argument for slot in render is deprecated
+        and will be removed in the next version. Use the `slot` keyword argument instead.
+      MSG
+
+      slot = overrides.fetch(:slot, slot || :default)
       classes = overrides.delete(:class)
       result = []
 

--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,8 @@ button_classes.render
 button_classes.render(color: :red, size: :xl, icon: true)
 ```
 
+> **Note**: `slot` and `class` are reserved words and cannot be used as variants keys! Continue reading for usage.
+
 ## Compound Variants
 
 ```ruby
@@ -177,10 +179,10 @@ end
 
 ```erb
 <div>
-  <div class="<%= alert_classes.render(:head) %>">
+  <div class="<%= alert_classes.render(slot: :head) %>">
     Head of alert
   </div>
-  <div class="<%= alert_classes.render(:body) %>">
+  <div class="<%= alert_classes.render(slot: :body) %>">
     Body of alert
   </div>
 </div>
@@ -262,19 +264,19 @@ alert_classes.render
 alert_classes.render(color: :red)
 
 # render slot with defaults variants
-alert_classes.render(:body)
+alert_classes.render(slot: :body)
 
 # render slot with custom variants
-alert_classes.render(:body, color: :red)
+alert_classes.render(slot: :body, color: :red)
 
-# if slot not exist, throw error? return empty classes?
-alert_classes.render(:non_existent_slot, color: :red)
+# if slot not exist, return empty classes
+alert_classes.render(slot: :non_existent_slot, color: :red)
 
 # render default slot with custom class (will be merged)
 alert_classes.render(class: "...")
 
 # render slot with custom class (will be merged)
-alert_classes.render(:body, class: "...")
+alert_classes.render(slot: :body, class: "...")
 ```
 
 ## Use with Rails

--- a/test/merge_test.rb
+++ b/test/merge_test.rb
@@ -65,7 +65,7 @@ class MergeTest < Minitest::Test
       defaults variant: :filled
     end
 
-    assert_equal "rounded mb-4 bg-red-100 dark:bg-red-800", cv.render(:root)
-    assert_equal "font-bold mb-1 text-red-900 dark:text-red-50", cv.render(:title)
+    assert_equal "rounded mb-4 bg-red-100 dark:bg-red-800", cv.render(slot: :root)
+    assert_equal "font-bold mb-1 text-red-900 dark:text-red-50", cv.render(slot: :title)
   end
 end

--- a/test/slot_test.rb
+++ b/test/slot_test.rb
@@ -45,25 +45,25 @@ class SlotTest < Minitest::Test
   end
 
   def test_render_nonexistent_slot
-    assert_equal "", @cv.render(:nonexistent)
+    assert_equal "", @cv.render(slot: :nonexistent)
   end
 
   def test_render_slot_with_defaults
-    assert_equal "rounded py-3 px-5 mb-4 bg-green-100 dark:bg-green-800", @cv.render(:root)
+    assert_equal "rounded py-3 px-5 mb-4 bg-green-100 dark:bg-green-800", @cv.render(slot: :root)
   end
 
   def test_render_slot_with_variant
-    assert_equal "rounded py-3 px-5 mb-4 border border-green-700 dark:border-green-500", @cv.render(:root, variant: :outlined)
+    assert_equal "rounded py-3 px-5 mb-4 border border-green-700 dark:border-green-500", @cv.render(slot: :root, variant: :outlined)
   end
 
   def test_render_slot_without_base
-    assert_equal "text-green-700 dark:text-green-200", @cv.render(:message)
+    assert_equal "text-green-700 dark:text-green-200", @cv.render(slot: :message)
   end
 
   def test_render_slot_with_unused_variant
     assert_equal(
       "rounded py-3 px-5 mb-4 border border-green-700 dark:border-green-500",
-      @cv.render(:root, variant: :outlined, type: :button)
+      @cv.render(slot: :root, variant: :outlined, type: :button)
     )
   end
 end


### PR DESCRIPTION
We need to deprecate the usage of positional argument in the render method to specify the slot in favor of using a keyword argument.

In addition to unifying the way parameters are passed to the render method, this will allow us to free up positional arguments to implement the concept of traits, which I will develop in another PR, with a similar functionality to [FactoryBot's traits](https://thoughtbot.com/blog/remove-duplication-with-factorybots-traits).