### PR TITLE
Increment required ruby minimal version to 3.2

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,10 +8,10 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - "3.0"
-          - "3.1"
           - "3.2"
           - "3.3"
+          - "3.4"
+          - "3.5"
     steps:
       - uses: actions/checkout@v4
       - name: Setup Ruby ${{ matrix.ruby }}
@@ -28,10 +28,10 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - "3.0"
-          - "3.1"
           - "3.2"
           - "3.3"
+          - "3.4"
+          - "3.5"
     steps:
       - uses: actions/checkout@v4
       - name: Setup Ruby ${{ matrix.ruby }}

--- a/class_variants.gemspec
+++ b/class_variants.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*", "LICENSE", "README.md"]
 
   # ruby minimal version
-  s.required_ruby_version = Gem::Requirement.new(">= 3.0")
+  s.required_ruby_version = Gem::Requirement.new(">= 3.2")
 end


### PR DESCRIPTION
* Ruby 3.0 EOL: 2024-04-23
* Ruby 3.1 EOL: 2025-03-26